### PR TITLE
Pawn legal moves

### DIFF
--- a/src/Myg-Chess-Core/MyPawn.class.st
+++ b/src/Myg-Chess-Core/MyPawn.class.st
@@ -27,7 +27,7 @@ MyPawn >> renderPieceOn: aSquare [
 
 { #category : 'rendering' }
 MyPawn >> targetSquaresLegal: aBoolean [ 
-    | legalMoves moveOne moveTwo |
+    | legalMoves moveOne moveTwo captureLeft captureRight |
 
     legalMoves := OrderedCollection new.
 
@@ -44,5 +44,19 @@ MyPawn >> targetSquaresLegal: aBoolean [
         moveOne hasPiece not and: [ moveTwo hasPiece not ]
     ]) ifTrue: [ legalMoves addLast: moveTwo ].
 
-^legalMoves
+    "Définit les captures en diagonale"
+    captureLeft := self isWhite
+        ifTrue: [ square up left ]
+        ifFalse: [ square down left ].
+    captureRight := self isWhite
+        ifTrue: [ square up right ]
+        ifFalse: [ square down right ].
+
+    "Ajoute les cases de capture si elles contiennent une pièce adverse"
+    (captureLeft notNil and: [ captureLeft hasPiece and: [ captureLeft contents color ~= self color ]])
+        ifTrue: [ legalMoves addLast: captureLeft ].
+    (captureRight notNil and: [ captureRight hasPiece and: [ captureRight contents color ~= self color ]])
+        ifTrue: [ legalMoves addLast: captureRight ].
+
+    ^legalMoves
 ]

--- a/src/Myg-Chess-Tests/MyPawnTest.class.st
+++ b/src/Myg-Chess-Tests/MyPawnTest.class.st
@@ -6,6 +6,33 @@ Class {
 }
 
 { #category : 'tests' }
+MyPawnTest >> testDiagonalCapture [
+    | board whitePawn blackPawn legalMoves |
+
+    "Création d'un plateau vide"
+    board := MyChessBoard empty.
+    
+    "Création d'un pion blanc et d'un pion noir"
+    whitePawn := MyPawn white.
+    blackPawn := MyPawn black.
+
+    "Place un pion blanc sur la case 'd4'"
+    board at: 'd4' put: whitePawn.
+    
+    "Place un pion noir en diagonale sur les cases 'c5' et 'e5'"
+    board at: 'c5' put: blackPawn.
+    board at: 'e5' put: blackPawn.
+
+    "Récupère les mouvements légaux du pion blanc"
+    legalMoves := whitePawn targetSquaresLegal: true.
+
+    "Vérifie que le pion blanc peut capturer en diagonale"
+    self assert: (legalMoves includes: (board at: 'c5')).
+    self assert: (legalMoves includes: (board at: 'e5')).
+
+]
+
+{ #category : 'tests' }
 MyPawnTest >> testInitialDoubleMove [
     | pawn board legalMoves |
 


### PR DESCRIPTION
Methods and test for Pawn's legals move. Double move for the first move and diagonal capture